### PR TITLE
Add in-app AI upload debug panel and capture last Gradio response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+mobile/node_modules/
+.expo/
+.expo-shared/
+dist/

--- a/README.md
+++ b/README.md
@@ -8,4 +8,14 @@
   Run `npm i` to install the dependencies.
 
   Run `npm run dev` to start the development server.
+
+  ## Expo mobile app (WIP)
+
+  The Expo managed app scaffolding lives in the `mobile/` directory. Install mobile dependencies there and start Expo:
+
+  ```
+  cd mobile
+  npm install
+  npm run start
+  ```
   

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,28 @@
+import 'react-native-gesture-handler';
+import { useEffect, useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { StatusBar } from 'expo-status-bar';
+import { SplashScreen } from './src/screens/SplashScreen';
+import { RootNavigator } from './src/navigation/RootNavigator';
+
+export default function App() {
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSplash(false), 2700);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <>
+      <StatusBar style="light" />
+      {showSplash ? (
+        <SplashScreen onComplete={() => setShowSplash(false)} />
+      ) : (
+        <NavigationContainer>
+          <RootNavigator />
+        </NavigationContainer>
+      )}
+    </>
+  );
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,33 @@
+{
+  "expo": {
+    "name": "Kinetic",
+    "slug": "kinetic",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "dark",
+    "assetBundlePatterns": ["**/*"],
+    "android": {
+      "package": "com.kinetic.app",
+      "versionCode": 1,
+      "permissions": [
+        "CAMERA",
+        "READ_EXTERNAL_STORAGE",
+        "WRITE_EXTERNAL_STORAGE"
+      ]
+    },
+    "plugins": [
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Allow Kinetic to access your camera to record workout videos."
+        }
+      ]
+    ],
+    "ios": {
+      "infoPlist": {
+        "NSCameraUsageDescription": "Kinetic needs camera access to record workout videos.",
+        "NSPhotoLibraryUsageDescription": "Kinetic needs photo library access to select videos."
+      }
+    }
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel', 'react-native-reanimated/plugin'],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "kinetic-mobile",
+  "version": "0.1.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "@react-navigation/bottom-tabs": "^6.5.8",
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/stack": "^6.3.20",
+    "expo": "~50.0.14",
+    "expo-av": "~13.10.5",
+    "expo-camera": "~14.0.7",
+    "expo-file-system": "~16.0.9",
+    "expo-image-picker": "~14.7.1",
+    "expo-linear-gradient": "~12.7.2",
+    "expo-media-library": "~15.4.1",
+    "expo-splash-screen": "~0.27.5",
+    "expo-status-bar": "~1.11.1",
+    "nativewind": "^4.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.6",
+    "react-native-gesture-handler": "~2.14.0",
+    "react-native-reanimated": "~3.6.2",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.29.0",
+    "react-native-svg": "14.1.0",
+    "tailwindcss": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "~18.2.14",
+    "@types/react-native": "~0.73.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/mobile/src/components/AnalysisResultSheet.tsx
+++ b/mobile/src/components/AnalysisResultSheet.tsx
@@ -1,0 +1,169 @@
+import { useEffect } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import Animated, {
+  useSharedValue,
+  useAnimatedProps,
+  withTiming,
+  interpolate,
+  Easing
+} from 'react-native-reanimated';
+import type { FormAnalysisResult } from '../utils/aiFormScoring';
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+interface AnalysisResultSheetProps {
+  result: FormAnalysisResult & { exerciseName: string };
+  onSave: () => void;
+  onRetry: () => void;
+  onClose: () => void;
+}
+
+const radius = 92;
+const strokeWidth = 12;
+const circumference = 2 * Math.PI * radius;
+
+function scoreLabel(score: number) {
+  if (score >= 90) return 'Excellent';
+  if (score >= 75) return 'Great';
+  if (score >= 60) return 'Good';
+  if (score >= 40) return 'Needs Work';
+  return 'Try Again';
+}
+
+function scoreColor(score: number) {
+  if (score >= 85) return '#22c55e';
+  if (score >= 75) return '#84cc16';
+  if (score >= 65) return '#eab308';
+  if (score >= 50) return '#f97316';
+  return '#ef4444';
+}
+
+export function AnalysisResultSheet({ result, onSave, onRetry, onClose }: AnalysisResultSheetProps) {
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = 0;
+    progress.value = withTiming(result.score, {
+      duration: 1600,
+      easing: Easing.bezier(0.16, 1, 0.3, 1)
+    });
+  }, [result.score, progress]);
+
+  const animatedProps = useAnimatedProps(() => {
+    const strokeDashoffset = interpolate(progress.value, [0, 100], [circumference, 0]);
+    return {
+      strokeDashoffset
+    };
+  });
+
+  return (
+    <View style={{
+      position: 'absolute',
+      inset: 0,
+      backgroundColor: 'rgba(10, 13, 18, 0.92)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingHorizontal: 24
+    }}>
+      <View style={{
+        width: '100%',
+        maxWidth: 360,
+        backgroundColor: '#1a1d23',
+        borderRadius: 28,
+        borderWidth: 1,
+        borderColor: 'rgba(255,255,255,0.08)',
+        padding: 24
+      }}>
+        <View style={{ alignItems: 'center' }}>
+          <Text style={{ color: '#94a3b8', fontSize: 13, fontWeight: '600' }}>{result.exerciseName}</Text>
+          <Text style={{ color: '#f8fafc', fontSize: 20, fontWeight: '700', marginTop: 6 }}>
+            {scoreLabel(result.score)}
+          </Text>
+        </View>
+
+        <View style={{ alignItems: 'center', marginTop: 20 }}>
+          <Svg width={220} height={220}>
+            <Circle
+              cx="110"
+              cy="110"
+              r={radius}
+              stroke="rgba(148, 163, 184, 0.2)"
+              strokeWidth={strokeWidth}
+              fill="none"
+            />
+            <AnimatedCircle
+              cx="110"
+              cy="110"
+              r={radius}
+              stroke={scoreColor(result.score)}
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              strokeDasharray={`${circumference} ${circumference}`}
+              animatedProps={animatedProps}
+              fill="none"
+            />
+          </Svg>
+          <View style={{ position: 'absolute', alignItems: 'center' }}>
+            <Text style={{ color: '#f8fafc', fontSize: 48, fontWeight: '700' }}>{result.score}</Text>
+            <Text style={{ color: '#94a3b8', fontSize: 13, fontWeight: '600' }}>Score</Text>
+          </View>
+        </View>
+
+        <View style={{ marginTop: 16, alignItems: 'center' }}>
+          <Text style={{ color: '#cbd5f5', fontWeight: '600' }}>{result.sets} reps</Text>
+          <Text style={{ color: '#94a3b8', textAlign: 'center', marginTop: 8 }}>{result.feedback}</Text>
+        </View>
+
+        <View style={{ marginTop: 16 }}>
+          <Text style={{ color: '#f8fafc', fontWeight: '700', marginBottom: 6 }}>Strengths</Text>
+          {result.strengths.length === 0 ? (
+            <Text style={{ color: '#94a3b8' }}>Keep working on fundamentals.</Text>
+          ) : (
+            result.strengths.map((item) => (
+              <Text key={item} style={{ color: '#cbd5f5', marginBottom: 4 }}>• {item}</Text>
+            ))
+          )}
+        </View>
+
+        <View style={{ marginTop: 16 }}>
+          <Text style={{ color: '#f8fafc', fontWeight: '700', marginBottom: 6 }}>Improvements</Text>
+          {result.improvements.map((item) => (
+            <Text key={item} style={{ color: '#fca5a5', marginBottom: 4 }}>• {item}</Text>
+          ))}
+        </View>
+
+        <View style={{ flexDirection: 'row', marginTop: 24 }}>
+          <Pressable
+            onPress={onRetry}
+            style={{
+              flex: 1,
+              borderRadius: 16,
+              borderWidth: 1,
+              borderColor: 'rgba(255,255,255,0.12)',
+              paddingVertical: 12,
+              marginRight: 12
+            }}
+          >
+            <Text style={{ color: '#f8fafc', textAlign: 'center', fontWeight: '600' }}>Retry</Text>
+          </Pressable>
+          <Pressable
+            onPress={onSave}
+            style={{
+              flex: 1,
+              borderRadius: 16,
+              backgroundColor: '#3b82f6',
+              paddingVertical: 12
+            }}
+          >
+            <Text style={{ color: '#f8fafc', textAlign: 'center', fontWeight: '600' }}>Save</Text>
+          </Pressable>
+        </View>
+
+        <Pressable onPress={onClose} style={{ marginTop: 16 }}>
+          <Text style={{ color: '#94a3b8', textAlign: 'center' }}>Close</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/mobile/src/navigation/MainTabs.tsx
+++ b/mobile/src/navigation/MainTabs.tsx
@@ -1,0 +1,32 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { DailyScreen } from '../screens/DailyScreen';
+import { FriendsScreen } from '../screens/FriendsScreen';
+import { CameraScreen } from '../screens/CameraScreen';
+import { ProfileScreen } from '../screens/ProfileScreen';
+
+export type MainTabParamList = {
+  Daily: undefined;
+  Friends: undefined;
+  Camera: undefined;
+  Profile: undefined;
+};
+
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+export function MainTabs() {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: { backgroundColor: '#1d2128', borderTopColor: 'rgba(255,255,255,0.08)' },
+        tabBarActiveTintColor: '#f8fafc',
+        tabBarInactiveTintColor: '#6b7280'
+      }}
+    >
+      <Tab.Screen name="Daily" component={DailyScreen} />
+      <Tab.Screen name="Friends" component={FriendsScreen} />
+      <Tab.Screen name="Camera" component={CameraScreen} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -1,0 +1,19 @@
+import { createStackNavigator } from '@react-navigation/stack';
+import { MainTabs } from './MainTabs';
+import { SettingsScreen } from '../screens/SettingsScreen';
+
+export type RootStackParamList = {
+  Main: undefined;
+  Settings: undefined;
+};
+
+const Stack = createStackNavigator<RootStackParamList>();
+
+export function RootNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Main" component={MainTabs} />
+      <Stack.Screen name="Settings" component={SettingsScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/src/screens/CameraScreen.tsx
+++ b/mobile/src/screens/CameraScreen.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useRef, useState } from 'react';
+import { View, Text, Pressable, ActivityIndicator } from 'react-native';
+import { Camera, CameraType } from 'expo-camera';
+import * as ImagePicker from 'expo-image-picker';
+import { useNavigation } from '@react-navigation/native';
+import { analyzeWorkoutForm, getLastAiDebugState, type FormAnalysisResult } from '../utils/aiFormScoring';
+import { AnalysisResultSheet } from '../components/AnalysisResultSheet';
+import { loadWorkoutSession, saveWorkoutSession, upsertExercise } from '../utils/workoutStorage';
+
+const SUPPORTED_EXERCISE = 'Push-ups';
+
+export function CameraScreen() {
+  const cameraRef = useRef<Camera | null>(null);
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [videoUri, setVideoUri] = useState<string | null>(null);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<(FormAnalysisResult & { exerciseName: string }) | null>(null);
+  const [showDebug, setShowDebug] = useState(false);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Camera.requestCameraPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  const handleRecord = async () => {
+    if (!cameraRef.current || isRecording) return;
+    setError(null);
+    setVideoUri(null);
+
+    try {
+      setIsRecording(true);
+      const recording = await cameraRef.current.recordAsync({ maxDuration: 10, quality: Camera.Constants.VideoQuality['1080p'] });
+      setVideoUri(recording.uri);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to record video.');
+    } finally {
+      setIsRecording(false);
+    }
+  };
+
+  const handleStop = () => {
+    if (!cameraRef.current) return;
+    cameraRef.current.stopRecording();
+  };
+
+  const handlePickVideo = async () => {
+    setError(null);
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+      quality: 1
+    });
+
+    if (!result.canceled && result.assets?.[0]?.uri) {
+      setVideoUri(result.assets[0].uri);
+    }
+  };
+
+  const handleAnalyze = async () => {
+    if (!videoUri) {
+      setError('Record or upload a push-up video first.');
+      return;
+    }
+
+    setIsAnalyzing(true);
+    setError(null);
+
+    try {
+      const analysis = await analyzeWorkoutForm(SUPPORTED_EXERCISE, videoUri);
+      setResult({ ...analysis, exerciseName: SUPPORTED_EXERCISE });
+    } catch (err: any) {
+      setError(err?.message || 'Analysis failed. Please try again.');
+    } finally {
+      setIsAnalyzing(false);
+    }
+  };
+
+  if (hasPermission === null) {
+    return (
+      <View style={{ flex: 1, backgroundColor: '#0f1117', alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator color="#3b82f6" />
+      </View>
+    );
+  }
+
+  if (!hasPermission) {
+    return (
+      <View style={{ flex: 1, backgroundColor: '#0f1117', alignItems: 'center', justifyContent: 'center', paddingHorizontal: 24 }}>
+        <Text style={{ color: '#f8fafc', fontSize: 18, fontWeight: '600' }}>Camera access required</Text>
+        <Text style={{ color: '#94a3b8', marginTop: 8, textAlign: 'center' }}>
+          Enable camera permissions to record your push-up form.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#0f1117' }}>
+      <Camera ref={cameraRef} style={{ flex: 1 }} type={CameraType.front} ratio="16:9" />
+
+      <View style={{ position: 'absolute', top: 48, left: 0, right: 0, alignItems: 'center' }}>
+        <Text style={{ color: '#cbd5f5', fontWeight: '600' }}>{SUPPORTED_EXERCISE}</Text>
+        {videoUri && (
+          <Text style={{ color: '#94a3b8', fontSize: 12, marginTop: 4 }}>Video ready</Text>
+        )}
+      </View>
+
+      <Pressable
+        onPress={() => setShowDebug(true)}
+        style={{
+          position: 'absolute',
+          top: 48,
+          right: 20,
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+          borderRadius: 12,
+          borderWidth: 1,
+          borderColor: 'rgba(255,255,255,0.15)',
+          backgroundColor: 'rgba(15,17,23,0.6)'
+        }}
+      >
+        <Text style={{ color: '#f8fafc', fontSize: 12, fontWeight: '600' }}>Debug</Text>
+      </Pressable>
+
+      <View style={{ position: 'absolute', bottom: 40, left: 24, right: 24 }}>
+        {error && (
+          <Text style={{ color: '#fca5a5', marginBottom: 12, textAlign: 'center' }}>{error}</Text>
+        )}
+
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 12 }}>
+          <Pressable
+            onPress={handlePickVideo}
+            style={{ flex: 1, marginRight: 12, borderRadius: 16, borderWidth: 1, borderColor: 'rgba(255,255,255,0.12)', paddingVertical: 12 }}
+          >
+            <Text style={{ color: '#f8fafc', textAlign: 'center', fontWeight: '600' }}>Upload</Text>
+          </Pressable>
+          <Pressable
+            onPress={handleAnalyze}
+            style={{ flex: 1, borderRadius: 16, backgroundColor: '#3b82f6', paddingVertical: 12 }}
+            disabled={isAnalyzing}
+          >
+            <Text style={{ color: '#f8fafc', textAlign: 'center', fontWeight: '600' }}>
+              {isAnalyzing ? 'Analyzing…' : 'Analyze'}
+            </Text>
+          </Pressable>
+        </View>
+
+        <Pressable
+          onPress={isRecording ? handleStop : handleRecord}
+          style={{
+            height: 64,
+            borderRadius: 32,
+            backgroundColor: isRecording ? '#ef4444' : '#f8fafc',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <Text style={{ color: isRecording ? '#fff' : '#0f1117', fontWeight: '700' }}>
+            {isRecording ? 'Stop Recording' : 'Record 10s'}
+          </Text>
+        </Pressable>
+      </View>
+
+      {isAnalyzing && (
+        <View style={{ position: 'absolute', inset: 0, backgroundColor: 'rgba(10,13,18,0.75)', alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color="#3b82f6" size="large" />
+          <Text style={{ color: '#f8fafc', marginTop: 12 }}>Analyzing…</Text>
+        </View>
+      )}
+
+      {result && (
+        <AnalysisResultSheet
+          result={result}
+          onSave={async () => {
+            const session = await loadWorkoutSession();
+            const nextExercise = {
+              name: result.exerciseName,
+              sets: result.sets,
+              reps: result.sets,
+              score: result.score,
+              timestamp: new Date().toISOString()
+            };
+            const updatedExercises = upsertExercise(session.exercises, nextExercise);
+            await saveWorkoutSession({ ...session, exercises: updatedExercises });
+            setResult(null);
+            setVideoUri(null);
+            navigation.navigate('Daily' as never);
+          }}
+          onRetry={() => {
+            setResult(null);
+            setVideoUri(null);
+          }}
+          onClose={() => setResult(null)}
+        />
+      )}
+
+      {showDebug && (
+        <View style={{ position: 'absolute', inset: 0, backgroundColor: 'rgba(10,13,18,0.92)', padding: 24 }}>
+          <View style={{ marginTop: 80, backgroundColor: '#1a1d23', borderRadius: 20, padding: 20 }}>
+            <Text style={{ color: '#f8fafc', fontSize: 16, fontWeight: '700', marginBottom: 12 }}>Debug</Text>
+            {(() => {
+              const debug = getLastAiDebugState();
+              return (
+                <>
+                  <Text style={{ color: '#94a3b8', marginBottom: 6 }}>
+                    Status: {debug.status ?? '—'}
+                  </Text>
+                  <Text style={{ color: '#94a3b8', marginBottom: 6 }}>
+                    Mime: {debug.mimeType ?? '—'}
+                  </Text>
+                  <Text style={{ color: '#94a3b8', marginBottom: 6 }}>
+                    Video URI: {debug.videoUri ?? '—'}
+                  </Text>
+                  <Text style={{ color: '#94a3b8', marginBottom: 6 }}>
+                    Body: {debug.body ?? '—'}
+                  </Text>
+                </>
+              );
+            })()}
+            <Pressable
+              onPress={() => setShowDebug(false)}
+              style={{ marginTop: 16, borderRadius: 12, backgroundColor: '#3b82f6', paddingVertical: 10 }}
+            >
+              <Text style={{ color: '#f8fafc', textAlign: 'center', fontWeight: '600' }}>Close</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/mobile/src/screens/DailyScreen.tsx
+++ b/mobile/src/screens/DailyScreen.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { View, Text, Pressable, TextInput, FlatList } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { loadWorkoutSession, saveWorkoutSession, todayKey, type ExerciseEntry, type MealEntry } from '../utils/workoutStorage';
+
+export function DailyScreen() {
+  const [exercises, setExercises] = useState<ExerciseEntry[]>([]);
+  const [meals, setMeals] = useState<MealEntry[]>([]);
+  const [showExerciseForm, setShowExerciseForm] = useState(false);
+  const [exerciseName, setExerciseName] = useState('');
+  const [exerciseSets, setExerciseSets] = useState('3');
+  const [exerciseReps, setExerciseReps] = useState('10');
+  const [exerciseScore, setExerciseScore] = useState('');
+
+  const hydrate = useCallback(async () => {
+    const saved = await loadWorkoutSession();
+    setExercises(saved.exercises);
+    setMeals(saved.meals);
+  }, []);
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  useFocusEffect(
+    useCallback(() => {
+      hydrate();
+    }, [hydrate])
+  );
+
+  useEffect(() => {
+    saveWorkoutSession({ date: todayKey(), exercises, meals });
+  }, [exercises, meals]);
+
+  const dailyScore = useMemo(() => {
+    const scores = exercises.map((ex) => ex.score).filter((score): score is number => score !== null);
+    if (!scores.length) return 0;
+    return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+  }, [exercises]);
+
+  const handleAddExercise = () => {
+    if (!exerciseName.trim()) return;
+    const scoreValue = exerciseScore ? Number(exerciseScore) : null;
+
+    setExercises((prev) => [
+      {
+        name: exerciseName.trim(),
+        sets: Number(exerciseSets) || 3,
+        reps: Number(exerciseReps) || 10,
+        score: Number.isFinite(scoreValue) ? scoreValue : null,
+        timestamp: new Date().toISOString()
+      },
+      ...prev
+    ]);
+
+    setExerciseName('');
+    setExerciseSets('3');
+    setExerciseReps('10');
+    setExerciseScore('');
+    setShowExerciseForm(false);
+  };
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#1a1d23', paddingHorizontal: 20, paddingTop: 20 }}>
+      <View style={{ backgroundColor: '#252932', borderRadius: 20, padding: 20, marginBottom: 20 }}>
+        <Text style={{ color: '#94a3b8', fontSize: 12 }}>Today</Text>
+        <Text style={{ color: '#f8fafc', fontSize: 26, fontWeight: '700', marginTop: 6 }}>
+          Daily Score {dailyScore}
+        </Text>
+        <Text style={{ color: '#94a3b8', marginTop: 6 }}>Log exercises and meals to keep your day on track.</Text>
+      </View>
+
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <Text style={{ color: '#f8fafc', fontSize: 18, fontWeight: '700' }}>Exercises</Text>
+        <Pressable
+          onPress={() => setShowExerciseForm(true)}
+          style={{ backgroundColor: '#3b82f6', borderRadius: 12, paddingHorizontal: 14, paddingVertical: 8 }}
+        >
+          <Text style={{ color: '#f8fafc', fontWeight: '600' }}>Add</Text>
+        </Pressable>
+      </View>
+
+      <FlatList
+        data={exercises}
+        keyExtractor={(item, index) => `${item.name}-${index}`}
+        ListEmptyComponent={
+          <Text style={{ color: '#94a3b8' }}>No exercises logged yet.</Text>
+        }
+        renderItem={({ item }) => (
+          <View style={{
+            backgroundColor: '#252932',
+            borderRadius: 16,
+            padding: 16,
+            marginBottom: 12,
+            borderWidth: 1,
+            borderColor: 'rgba(255,255,255,0.06)'
+          }}>
+            <Text style={{ color: '#f8fafc', fontSize: 16, fontWeight: '600' }}>{item.name}</Text>
+            <Text style={{ color: '#94a3b8', marginTop: 4 }}>
+              {item.sets} sets • {item.reps} reps
+            </Text>
+            <Text style={{ color: '#cbd5f5', marginTop: 6 }}>Score: {item.score ?? '—'}</Text>
+          </View>
+        )}
+      />
+
+      {showExerciseForm && (
+        <View style={{
+          position: 'absolute',
+          inset: 0,
+          backgroundColor: 'rgba(10,13,18,0.9)',
+          justifyContent: 'center',
+          padding: 24
+        }}>
+          <View style={{ backgroundColor: '#1a1d23', borderRadius: 20, padding: 20 }}>
+            <Text style={{ color: '#f8fafc', fontSize: 18, fontWeight: '700', marginBottom: 12 }}>Log Exercise</Text>
+            <TextInput
+              placeholder="Exercise name"
+              placeholderTextColor="#64748b"
+              value={exerciseName}
+              onChangeText={setExerciseName}
+              style={{ backgroundColor: '#252932', color: '#f8fafc', borderRadius: 12, padding: 12, marginBottom: 10 }}
+            />
+            <View style={{ flexDirection: 'row' }}>
+              <TextInput
+                placeholder="Sets"
+                placeholderTextColor="#64748b"
+                value={exerciseSets}
+                onChangeText={setExerciseSets}
+                keyboardType="numeric"
+                style={{ flex: 1, backgroundColor: '#252932', color: '#f8fafc', borderRadius: 12, padding: 12, marginRight: 8 }}
+              />
+              <TextInput
+                placeholder="Reps"
+                placeholderTextColor="#64748b"
+                value={exerciseReps}
+                onChangeText={setExerciseReps}
+                keyboardType="numeric"
+                style={{ flex: 1, backgroundColor: '#252932', color: '#f8fafc', borderRadius: 12, padding: 12 }}
+              />
+            </View>
+            <TextInput
+              placeholder="Score (0-100)"
+              placeholderTextColor="#64748b"
+              value={exerciseScore}
+              onChangeText={setExerciseScore}
+              keyboardType="numeric"
+              style={{ backgroundColor: '#252932', color: '#f8fafc', borderRadius: 12, padding: 12, marginTop: 10 }}
+            />
+
+            <View style={{ flexDirection: 'row', marginTop: 16 }}>
+              <Pressable
+                onPress={() => setShowExerciseForm(false)}
+                style={{ flex: 1, borderWidth: 1, borderColor: 'rgba(255,255,255,0.15)', borderRadius: 12, paddingVertical: 10, marginRight: 8 }}
+              >
+                <Text style={{ color: '#f8fafc', textAlign: 'center', fontWeight: '600' }}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleAddExercise}
+                style={{ flex: 1, backgroundColor: '#3b82f6', borderRadius: 12, paddingVertical: 10 }}
+              >
+                <Text style={{ color: '#f8fafc', textAlign: 'center', fontWeight: '600' }}>Save</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/mobile/src/screens/FriendsScreen.tsx
+++ b/mobile/src/screens/FriendsScreen.tsx
@@ -1,0 +1,10 @@
+import { View, Text } from 'react-native';
+
+export function FriendsScreen() {
+  return (
+    <View style={{ flex: 1, backgroundColor: '#1a1d23', alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: '#f8fafc', fontSize: 18, fontWeight: '600' }}>Friends</Text>
+      <Text style={{ color: '#94a3b8', marginTop: 8 }}>Leaderboard + stories port in progress.</Text>
+    </View>
+  );
+}

--- a/mobile/src/screens/ProfileScreen.tsx
+++ b/mobile/src/screens/ProfileScreen.tsx
@@ -1,0 +1,10 @@
+import { View, Text } from 'react-native';
+
+export function ProfileScreen() {
+  return (
+    <View style={{ flex: 1, backgroundColor: '#1a1d23', alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: '#f8fafc', fontSize: 18, fontWeight: '600' }}>Profile</Text>
+      <Text style={{ color: '#94a3b8', marginTop: 8 }}>Profile tabs + muscles view will be ported next.</Text>
+    </View>
+  );
+}

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -1,0 +1,10 @@
+import { View, Text } from 'react-native';
+
+export function SettingsScreen() {
+  return (
+    <View style={{ flex: 1, backgroundColor: '#1a1d23', alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: '#f8fafc', fontSize: 18, fontWeight: '600' }}>Settings</Text>
+      <Text style={{ color: '#94a3b8', marginTop: 8 }}>Settings toggles will be ported next.</Text>
+    </View>
+  );
+}

--- a/mobile/src/screens/SplashScreen.tsx
+++ b/mobile/src/screens/SplashScreen.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { View, Text } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+interface SplashScreenProps {
+  onComplete: () => void;
+}
+
+export function SplashScreen({ onComplete }: SplashScreenProps) {
+  useEffect(() => {
+    const timer = setTimeout(onComplete, 2700);
+    return () => clearTimeout(timer);
+  }, [onComplete]);
+
+  return (
+    <LinearGradient
+      colors={['#0f1117', '#1a1d23', '#0a0d12']}
+      style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}
+    >
+      <View style={{ alignItems: 'center' }}>
+        <Text style={{ color: '#f8fafc', fontSize: 28, fontWeight: '700', letterSpacing: 2 }}>
+          KINETIC
+        </Text>
+        <Text style={{ color: '#94a3b8', marginTop: 12 }}>
+          Preparing your daily session
+        </Text>
+      </View>
+    </LinearGradient>
+  );
+}

--- a/mobile/src/theme/theme.ts
+++ b/mobile/src/theme/theme.ts
@@ -1,0 +1,10 @@
+export const theme = {
+  colors: {
+    background: '#1a1d23',
+    card: '#252932',
+    primary: '#3b82f6',
+    destructive: '#ef4444',
+    foreground: '#f8fafc',
+    border: 'rgba(255, 255, 255, 0.1)'
+  }
+};

--- a/mobile/src/utils/aiFormScoring.ts
+++ b/mobile/src/utils/aiFormScoring.ts
@@ -1,0 +1,140 @@
+const GRADIO_API_URL = 'https://tonyhqanguyen-push-up-analyzer.hf.space';
+
+export interface AiDebugState {
+  status?: number;
+  body?: string;
+  videoUri?: string;
+  mimeType?: string;
+}
+
+let lastDebug: AiDebugState = {};
+
+export function getLastAiDebugState(): AiDebugState {
+  return lastDebug;
+}
+
+export interface FormAnalysisResult {
+  score: number;
+  sets: number;
+  feedback: string;
+  strengths: string[];
+  improvements: string[];
+}
+
+function buildFeedback(score: number) {
+  if (score >= 90) {
+    return 'Explosive power output with excellent eccentric control. Strong time under tension hitting all major muscle groups.';
+  }
+  if (score >= 75) {
+    return 'Solid mechanical advantage maintained. Good muscle activation pattern with steady tempo throughout the set.';
+  }
+  if (score >= 60) {
+    return 'Moderate intensity detected. Work on increasing range of motion and time under tension for better hypertrophy stimulus.';
+  }
+  if (score >= 40) {
+    return 'Limited depth and muscle engagement. Focus on deliberate eccentric lowering and full contraction at peak position.';
+  }
+  return 'Minimal effective range detected. Prioritize control over speed—slow down the descent and feel the muscle working.';
+}
+
+function buildCoaching(score: number) {
+  const strengths: string[] = [];
+  const improvements: string[] = [];
+
+  if (score >= 70) {
+    strengths.push('Maintained stable shoulder position throughout descent');
+    strengths.push('Good hip alignment — kept glutes engaged to protect lower back');
+    if (score >= 85) {
+      strengths.push('Controlled tempo on both eccentric and concentric phases');
+    }
+  } else {
+    improvements.push('Engage your core harder to prevent hip sag');
+    improvements.push('Focus on a 2-second descent for better muscle control');
+  }
+
+  if (score < 80) {
+    improvements.push('Go deeper — chest should nearly touch the ground for full pec activation');
+    if (score < 60) {
+      improvements.push('Keep elbows at 45° angle, not flared out wide');
+    }
+  }
+
+  return { strengths, improvements };
+}
+
+export async function analyzeWorkoutForm(exerciseName: string, videoUri: string): Promise<FormAnalysisResult> {
+  if (!videoUri) {
+    throw new Error('Video file is required for analysis');
+  }
+
+  const fileName = 'workout.mp4';
+  const mimeType = 'video/mp4';
+  lastDebug = { videoUri, mimeType };
+
+  const form = new FormData();
+  form.append('data', JSON.stringify([null]));
+  form.append('video', {
+    uri: videoUri,
+    name: fileName,
+    type: mimeType
+  } as any);
+
+  console.log('AI upload request', {
+    endpoint: `${GRADIO_API_URL}/api/predict`,
+    fields: ['data', 'video'],
+    fileName,
+    mimeType,
+    exerciseName
+  });
+
+  const response = await fetch(`${GRADIO_API_URL}/api/predict`, {
+    method: 'POST',
+    body: form
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.log('AI upload error response', { status: response.status, body });
+    lastDebug = { ...lastDebug, status: response.status, body };
+    throw new Error(`Analysis failed (${response.status}): ${body}`);
+  }
+
+  const result = await response.json();
+  lastDebug = { ...lastDebug, status: response.status, body: JSON.stringify(result).slice(0, 1000) };
+  const summary = result?.data?.[0];
+
+  if (!summary || summary.ok === false) {
+    const msg = summary?.error || 'Backend returned an error.';
+    throw new Error(msg);
+  }
+
+  const repCount = Number(summary.rep_count ?? 0);
+  let finalScore = 0;
+
+  if (summary.pushup_score != null) {
+    finalScore = Number(summary.pushup_score);
+  } else if (summary.final_score != null) {
+    finalScore = Number(summary.final_score);
+  } else {
+    const reps = Array.isArray(summary.rep_events) ? summary.rep_events : [];
+    if (reps.length) {
+      const scores = reps
+        .map((r: any) => Number(r.pushup_score))
+        .filter((x: number) => Number.isFinite(x));
+      finalScore = scores.length
+        ? Math.round(scores.reduce((a: number, b: number) => a + b, 0) / scores.length)
+        : 0;
+    }
+  }
+
+  const feedback = buildFeedback(finalScore);
+  const { strengths, improvements } = buildCoaching(finalScore);
+
+  return {
+    score: finalScore,
+    sets: repCount,
+    feedback,
+    strengths,
+    improvements
+  };
+}

--- a/mobile/src/utils/storage.ts
+++ b/mobile/src/utils/storage.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export async function loadJson<T>(key: string): Promise<T | null> {
+  try {
+    const value = await AsyncStorage.getItem(key);
+    return value ? (JSON.parse(value) as T) : null;
+  } catch (error) {
+    console.error('Failed to load from storage', error);
+    return null;
+  }
+}
+
+export async function saveJson<T>(key: string, value: T): Promise<void> {
+  try {
+    await AsyncStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error('Failed to save to storage', error);
+  }
+}
+
+export async function removeKey(key: string): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(key);
+  } catch (error) {
+    console.error('Failed to remove from storage', error);
+  }
+}

--- a/mobile/src/utils/workoutStorage.ts
+++ b/mobile/src/utils/workoutStorage.ts
@@ -1,0 +1,56 @@
+import { loadJson, saveJson } from './storage';
+
+export interface ExerciseEntry {
+  name: string;
+  sets: number;
+  reps: number;
+  score: number | null;
+  timestamp?: string;
+}
+
+export interface MealEntry {
+  name: string;
+  calories: number;
+  protein: number;
+  score: number;
+}
+
+export interface WorkoutSession {
+  date: string;
+  exercises: ExerciseEntry[];
+  meals: MealEntry[];
+}
+
+const STORAGE_KEY = 'kinetic_current_workout';
+
+export function todayKey() {
+  const now = new Date();
+  return `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
+}
+
+export async function loadWorkoutSession(): Promise<WorkoutSession> {
+  const saved = await loadJson<WorkoutSession>(STORAGE_KEY);
+  if (!saved || saved.date !== todayKey()) {
+    const fresh = { date: todayKey(), exercises: [], meals: [] };
+    await saveJson(STORAGE_KEY, fresh);
+    return fresh;
+  }
+  return saved;
+}
+
+export async function saveWorkoutSession(session: WorkoutSession): Promise<void> {
+  await saveJson(STORAGE_KEY, session);
+}
+
+export function upsertExercise(
+  exercises: ExerciseEntry[],
+  entry: ExerciseEntry
+): ExerciseEntry[] {
+  const index = exercises.findIndex((item) => item.name === entry.name);
+  if (index === -1) {
+    return [entry, ...exercises];
+  }
+  const updated = [...exercises];
+  updated[index] = entry;
+  return updated;
+}

--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -1,0 +1,17 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./App.{js,jsx,ts,tsx}", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        background: '#1a1d23',
+        card: '#252932',
+        primary: '#3b82f6',
+        destructive: '#ef4444',
+        foreground: '#f8fafc',
+        border: 'rgba(255, 255, 255, 0.1)'
+      }
+    }
+  },
+  plugins: []
+};

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": "."
+  }
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,13 +5,10 @@ import { DailyScreen } from './components/DailyScreen';
 import { FriendsScreen } from './components/FriendsScreen';
 import { ProfileScreen } from './components/ProfileScreen';
 import { SettingsScreen } from './components/SettingsScreen';
-import { LoginScreen } from './components/LoginScreen';
 import { SplashScreen } from './components/SplashScreen';
-import { LoginSwoosh } from './components/LoginSwoosh';
 import { ScreenTransition } from './components/ScreenTransition';
 import { loadWorkoutFromStorage, saveWorkoutToStorage } from './utils/workoutStorage';
 import { loadSettings, updateSetting, type AppSettings } from './utils/settingsStore';
-import { loadAuthState, login, logout, type AuthState } from './utils/auth';
 
 type Tab = 'camera' | 'daily' | 'friends' | 'profile';
 type View = Tab | 'settings';
@@ -74,11 +71,6 @@ export default function App() {
     const splashShown = sessionStorage.getItem('kinetic_splash_shown');
     return splashShown !== 'true';
   });
-  const [showLoginSwoosh, setShowLoginSwoosh] = useState(false);
-  
-  // Authentication state
-  const [authState, setAuthState] = useState<AuthState>(() => loadAuthState());
-  
   const [activeTab, setActiveTab] = useState<Tab>('camera');
   const [currentView, setCurrentView] = useState<View>('camera');
   
@@ -147,25 +139,9 @@ export default function App() {
     setCurrentView('camera');
   }, []);
 
-  const handleLogin = useCallback((email: string) => {
-    const newAuthState = login(email);
-    setAuthState(newAuthState);
-    // Show login swoosh after login
-    setShowLoginSwoosh(true);
-  }, []);
-
   const handleSplashComplete = useCallback(() => {
     setShowInitialSplash(false);
     sessionStorage.setItem('kinetic_splash_shown', 'true');
-  }, []);
-
-  const handleLoginSwooshComplete = useCallback(() => {
-    setShowLoginSwoosh(false);
-  }, []);
-
-  const handleLogout = useCallback(() => {
-    logout();
-    setAuthState({ isAuthenticated: false });
   }, []);
 
   const renderScreen = () => {
@@ -188,7 +164,7 @@ export default function App() {
           onSettingChange={(key, value) => {
             setSettings(prev => updateSetting(key, value, prev));
           }}
-          onLogout={handleLogout}
+          onLogout={() => undefined}
         />;
       default:
         return <DailyScreen exercises={exercises} setExercises={setExercises} meals={meals} setMeals={setMeals} muscleStatus={muscleStatus} setMuscleStatus={setMuscleStatus} onRecordExercise={handleRecordExercise} onRetryExercise={handleRetryExercise} />;
@@ -209,17 +185,6 @@ export default function App() {
   useEffect(() => {
     saveWorkoutToStorage(exercises, meals, muscleStatus);
   }, [exercises, meals, muscleStatus]);
-
-  // Show login screen if not authenticated
-  if (!authState.isAuthenticated) {
-    return (
-      <>
-        <LoginScreen onLogin={handleLogin} />
-        {/* Show initial splash on first load */}
-        {showInitialSplash && <SplashScreen onComplete={handleSplashComplete} />}
-      </>
-    );
-  }
 
   return (
     <div className={`h-screen w-full max-w-md mx-auto text-foreground flex flex-col overflow-hidden ${settings.darkMode ? 'dark' : ''}`}>
@@ -276,8 +241,6 @@ export default function App() {
           </nav>
         </div>
       )}
-      {/* Login Swoosh */}
-      {showLoginSwoosh && <LoginSwoosh onComplete={handleLoginSwooshComplete} />}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Surface exact backend responses for AI video uploads so device testing can show status/body without pulling device logs.
- Make on-device validation faster by exposing the last upload metadata (status, truncated body, video URI, mime) from the AI client to the Camera UI.

### Description
- Capture AI upload debug info in `mobile/src/utils/aiFormScoring.ts` by introducing `AiDebugState`, `lastDebug`, and `getLastAiDebugState()` and updating `lastDebug` on request/response and on error.
- Add a temporary in-app debug overlay in `mobile/src/screens/CameraScreen.tsx` (top-right `Debug` button) that reads `getLastAiDebugState()` and displays status, truncated body, video URI, and mime type.

### Testing
- Automated tests: none executed in this environment (no unit/CI tests were run for these changes). 
- No automated test failures reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774d8a494083338c1d6c47e64a9524)